### PR TITLE
Fix: Update GitHub Actions workflow to use PAT for release steps

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,7 +61,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
       with:
         tag_name: ${{ steps.create_tag.outputs.tag_name }}
         release_name: Release ${{ steps.create_tag.outputs.tag_name }}
@@ -73,7 +73,7 @@ jobs:
     - name: Upload Release Asset (Signed APK)
       uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         # The signing action outputs the path to the signed APK


### PR DESCRIPTION
This change modifies the `build-release.yml` workflow to use a Personal Access Token (PAT) for the 'Create GitHub Release' and 'Upload Release Asset' steps. This addresses potential permission issues that can occur when using the default GITHUB_TOKEN.

You will need to create a PAT with 'repo' and 'workflow' scopes and add it as a repository secret named RELEASE_PAT.