### PR TITLE
Fix incomplete APK build and resolve dependency conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RELEASE_DIR := release
-APK_SRC     := app/build/outputs/apk/release/app-release-unsigned.apk
+APK_SRC     := app/build/outputs/apk/release/ssh-socks-unsigned.apk
 APK_DEST    := $(RELEASE_DIR)/app-release.apk
 
 .PHONY: build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'com.example.sshinjector'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.sshinjector"
-        minSdk 21
-        targetSdk 33
+        minSdk 23
+        targetSdk 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -60,7 +60,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.10.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    def room_version = "2.5.0"
+    def room_version = "2.6.1"
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2' // Example Android Gradle Plugin version
+        classpath 'com.android.tools.build:gradle:8.2.2' // Example Android Gradle Plugin version
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         def nav_version = "2.5.3" // Ensure this matches app level
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"

--- a/gradlew
+++ b/gradlew
@@ -198,22 +198,26 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-echo "Placeholder gradlew: Would normally download Gradle from ${DISTRIBUTION_URL}"
-echo "This script is a placeholder and will not actually run Gradle."
-echo "To make this project buildable, obtain the real Gradle Wrapper scripts (gradlew, gradlew.bat) and the gradle/wrapper directory from a new Android Studio project or by running 'gradle wrapper'."
-echo "For CI purposes, this script will exit successfully if it was called with 'tasks' or 'assembleRelease' and create a dummy APK for the latter."
 
-if [ "$1" = "tasks" ]; then
-    echo "Simulating 'tasks' execution."
-    exit 0
-elif [ "$1" = "assembleDebug" ]; then
-    echo "Simulating 'assembleDebug' execution."
-    exit 0
-elif [ "$1" = "assembleRelease" ]; then
-    echo "Simulating 'assembleRelease' execution and creating a dummy APK."
-    mkdir -p app/build/outputs/apk/release/
-    rm -rf app/build/outputs/apk/release/* && zip -j app/build/outputs/apk/release/ssh-socks-unsigned.apk LICENSE
-    exit 0
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
+
+set -- \
+        "-Dorg.gradle.appname=$APP_BASE_NAME" \
+        -classpath "$CLASSPATH" \
+        org.gradle.wrapper.GradleWrapperMain \
+        "$@"
+
+# Stop when "xargs" is not available.
+if ! command -v xargs >/dev/null 2>&1
+then
+    die "xargs is not available"
 fi
 
 # Use "xargs" to parse quoted args.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -30,35 +30,63 @@ if "%DIRNAME%"=="" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
-echo Placeholder gradlew.bat
-echo This script is a placeholder and will not actually run Gradle.
-echo For CI purposes, this script will attempt to simulate 'tasks' or 'assembleRelease'.
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
-set GRADLE_WRAPPER_PROPERTIES_PATH=%APP_HOME%gradle\wrapper\gradle-wrapper.properties
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
-if not exist "%GRADLE_WRAPPER_PROPERTIES_PATH%" (
-    echo Warning: Missing Gradle wrapper properties file: %GRADLE_WRAPPER_PROPERTIES_PATH%.
-) else (
-    rem Basic extraction, might not be perfect
-    for /f "tokens=1,* delims==" %%a in ('findstr /b /c:"distributionUrl=" "%GRADLE_WRAPPER_PROPERTIES_PATH%"') do (
-        echo Info: Distribution URL found in wrapper properties.
-    )
-)
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
 
-set CMD_ARG1=%1
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
 
-if /I "%CMD_ARG1%" == "tasks" (
-    echo Simulating 'tasks' execution.
-    exit /B 0
-) else if /I "%CMD_ARG1%" == "assembleRelease" (
-    echo Simulating 'assembleRelease' execution and creating a dummy APK.
-    if not exist "app\build\outputs\apk\release" md "app\build\outputs\apk\release"
-    echo This is a dummy APK created by placeholder gradlew.bat > app\build\outputs\apk\release\ssh-socks-unsigned.apk
-    exit /B 0
-)
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
-echo Unsupported command: %*
-echo This placeholder gradlew.bat only supports 'tasks' or 'assembleRelease'.
+goto fail
 
-if "%OS%" == "Windows_NT" endlocal
-exit /B 1
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+goto fail
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+
+:end
+@rem End local scope for the variables with windows NT shell
+if %ERRORLEVEL% equ 0 goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega


### PR DESCRIPTION
This PR fixes the issue where the generated APK was incomplete (around 2.67 KB) due to a placeholder Gradle wrapper script and build configuration conflicts. It restores the official Gradle wrapper, upgrades the Android Gradle Plugin and SDK versions to meet dependency requirements, and adjusts the Makefile to correctly locate the build artifacts.

---
*PR created automatically by Jules for task [7343836432122987558](https://jules.google.com/task/7343836432122987558) started by @asnasn*